### PR TITLE
Remove hardcoded timeout, retries

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,9 +14,7 @@ var Batch = require('batch');
  */
 
 var Tray = module.exports = integration('tray.io')
-  .channels(['server', 'mobile', 'client'])
-  .timeout('5s')
-  .retries(5);
+  .channels(['server', 'mobile', 'client']);
 
 Tray.ensure(function(msg, settings){
   if (settings.workflows && Array.isArray(settings.workflows)) return; 


### PR DESCRIPTION
Linux's default TCP retransmission timeout is 3s, so if packets are lost
early in the connection then an otherwise successful connection will
time out. This allows this integration to use the default (currently
10s) to avoid that problem.

We're also removing the hardcoded retry value here since there's no
indication the default value won't do.